### PR TITLE
Add module to create IAM role for cross-account access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# terraform-aws-cross-account-role
+A Terraform module to create an IAM role for cross-account use. This module creates the role in the satellite account, but does not configure access in the source account.
+
+# Usage
+```hcl
+# Account 111111111111 configuration
+
+# Creates arn:aws:iam::111111111111:role/CrossAccountDeveloper
+module "cross_account_role" {
+  source                      = "github.com/azavea/terraform-aws-cross-account-role?ref=0.1.0"
+  name                        = "CrossAccountDeveloper"
+  principal_arns              = ["222222222222","arn:aws:iam::333333333333:user/MyUser"]
+  policy_arns                 = ["arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
+}
+```
+
+```hcl
+# Account 333333333333 configuration
+
+data "aws_iam_policy_document" "cross_account_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::333333333333:user/MyUser"]
+    }
+
+    resource = ["arn:aws:iam::111111111111:role/CrossAccountDeveloper"]
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+```
+
+
+# Variables
+
+- `name` - Name of the IAM Role you'd like to create.
+- `principal_arns` - List of ARNs for the AWS accounts, groups, users, or roles that should be able to access this role.
+- `policy_arns` - List of ARNs of IAM policies to attach to the IAM role.
+
+# Outputs
+
+- `cross_account_role_arn` - ARN of the IAM role.

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,24 @@
+data "aws_iam_policy_document" "cross_account_assume_role_policy" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${var.principal_arns}"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "cross_account_assume_role" {
+  name               = "${var.name}"
+  assume_role_policy = "${data.aws_iam_policy_document.cross_account_assume_role_policy.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "cross_account_assume_role" {
+  count = "${length(var.policy_arns)}"
+
+  role       = "${aws_iam_role.cross_account_assume_role.name}"
+  policy_arn = "${element(var.policy_arns, count.index)}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "role_arn" {
+  value = "${aws_iam_role.cross_account_assume_role.arn}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,14 @@
+variable "name" {
+  type        = "string"
+  description = "Name of the role being created."
+}
+
+variable "principal_arns" {
+  type        = "list"
+  description = "ARNs of accounts, groups, or users with the ability to assume this role."
+}
+
+variable "policy_arns" {
+  type        = "list"
+  description = "List of ARNs of policies to be associated with the created IAM role"
+}


### PR DESCRIPTION
This PR adds the necessary Terraform resources to create an IAM role for cross account access. Resources include:

- IAM policy to grant `sts:AssumeRole` access to a user-specified ARN
- IAM Role with the AssumeRole policy attached
- IAM policy attachments for user-specified IAM Policy ARNs

Fixes azavea/operations#101

# Testing:
I used this module to set up cross-account access between the root account and the Azavea DataHub account. In the root AWS account, I had to create an IAM policy to allow us to assume the Cross Account role:
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "Stmt1505245866000",
            "Effect": "Allow",
            "Action": [
                "sts:AssumeRole"
            ],
            "Resource": [
                "arn:aws:iam::<datahub account ID>:role/CrossAccountDeveloper"
            ]
        }
    ]
}
```
This policy was attached to `tnation` and `hcastro` IAM Users, but it could be attached to a Group as well. 

## Console access
- Signin to the Root account console.
- Go to the [Switch Role URL]( https://715496170458.signin.aws.amazon.com/switchrole?account=230546444088&roleName=CrossAccountDeveloper&displayName=CrossAccountRoleTes) and hit `Switch Role` to switch to the Fund account. The role should have S3 ReadOnly access, and ECR PowerUser access.


## CLI access
- Get the serial number of your Root account MFA device (i.e. `arn:aws:iam::<root account ID>:mfa/hcastro`)
- If you haven't already, setup an `azavea` AWS CLI profile with your root account Access Keys
- Setup a `datahub-developer` AWS CLI profile that uses the  `CrossAccountDeveloper` role and your root account API keys.
- Use the newly configured credentials to try an S3 operation
```bash
$ aws --profile datahub-developer configure set role_arn arn:aws:iam::<Datahub Account ID>:role/CrossAccountDeveloper
$ aws --profile datahub-developer configure set source_profile azavea
$ aws --profile datahub-developer configure set mfa_serial <MFA ARN>
$ aws --profile datahub-developer s3 ls
2017-06-23 09:02:23 aws-athena-query-results-987813201084-us-east-1
2017-06-23 11:59:29 datahub-catalogs-us-east-1
2017-06-23 11:07:19 datahub-config-us-east-1
2017-09-12 14:43:19 datahub-gt-ingests
2017-06-23 12:01:25 datahub-logs-us-east-1
2017-07-26 19:44:23 datahub-rawdata-us-east-1
2017-06-27 18:58:56 datahub-test-catalogs-us-east-1
2017-06-23 12:05:29 datahub-tiles-us-east-1
2016-09-17 10:08:09 simple-raster-processing
2016-08-31 20:43:07 tiler-perry-config.us-east-1.azavea.com
2016-08-31 21:13:12 tiler-perry-logs.us-east-1.azavea.com
2016-08-31 21:13:12 tiler-perry.us-east-1.azavea.com
2016-06-14 11:17:24 tiles.us-east-1.azavea.com
2016-09-28 14:15:51 us-tiles-test
```