### PR TITLE
Apply Terraform 0.12 compatibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
-# 0.1.0
+# Changelog
 
-Initial release
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## [1.0.0] - 2019-06-04
+
+### Changed
+
+- Upgrade to support Terraform 0.12
+  - Note: This change is **not** backwards-compatible with versions of
+    Terraform &lt; 0.12
+
+## [0.1.0] - 2017-09-13
+
+### Added
+
+- Initial release
+
+[unreleased]: ../../compare/1.0.0...HEAD
+[1.0.0]: ../../compare/0.1.0...1.0.0
+[0.1.0]: ../../releases/tag/0.1.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Terraform module to create an IAM role for cross-account use. This module crea
 
 # Creates arn:aws:iam::111111111111:role/CrossAccountDeveloper
 module "cross_account_role" {
-  source                      = "github.com/azavea/terraform-aws-cross-account-role?ref=0.1.0"
+  source                      = "github.com/azavea/terraform-aws-cross-account-role?ref=1.0.0"
   name                        = "CrossAccountDeveloper"
   principal_arns              = ["222222222222","arn:aws:iam::333333333333:user/MyUser"]
   policy_arns                 = ["arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser", "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ data "aws_iam_policy_document" "cross_account_assume_role_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${var.principal_arns}"]
+      identifiers = var.principal_arns
     }
 
     actions = ["sts:AssumeRole"]
@@ -12,13 +12,14 @@ data "aws_iam_policy_document" "cross_account_assume_role_policy" {
 }
 
 resource "aws_iam_role" "cross_account_assume_role" {
-  name               = "${var.name}"
-  assume_role_policy = "${data.aws_iam_policy_document.cross_account_assume_role_policy.json}"
+  name               = var.name
+  assume_role_policy = data.aws_iam_policy_document.cross_account_assume_role_policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "cross_account_assume_role" {
-  count = "${length(var.policy_arns)}"
+  count = length(var.policy_arns)
 
-  role       = "${aws_iam_role.cross_account_assume_role.name}"
-  policy_arn = "${element(var.policy_arns, count.index)}"
+  role       = aws_iam_role.cross_account_assume_role.name
+  policy_arn = element(var.policy_arns, count.index)
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,4 @@
 output "role_arn" {
-  value = "${aws_iam_role.cross_account_assume_role.arn}"
+  value = aws_iam_role.cross_account_assume_role.arn
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,14 +1,15 @@
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Name of the role being created."
 }
 
 variable "principal_arns" {
-  type        = "list"
+  type        = list(string)
   description = "ARNs of accounts, groups, or users with the ability to assume this role."
 }
 
 variable "policy_arns" {
-  type        = "list"
+  type        = list(string)
   description = "List of ARNs of policies to be associated with the created IAM role"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This PR applies Terraform `0.12` compatibility fixes.

<https://www.terraform.io/upgrade-guides/0-12.html>

I upgraded the module using `terraform 0.12upgrade` and bumped the module version. Because this change is not backwards compatible, I incremented the major version of the module from `0.1.0` to `1.0.0`. I updated the CHANGELOG and README files to reflect this bump.